### PR TITLE
Update veracode-pipeline-scan.yml

### DIFF
--- a/pipelines/veracode-pipeline-scan.yml
+++ b/pipelines/veracode-pipeline-scan.yml
@@ -1,5 +1,10 @@
 # Pipeline to run a Veracode pipeline scan, to scan for severities and CWEs according to the fetched security policy.
 # You can run this pipeline any time in the development process, to see if you are introducing security flaws in your code.
+# See https://docs.veracode.com/r/c_about_pipeline_scan for more info on pipeline scans
+
+# You will need to create the following secret pipeline variables:  VERACODE-API-ID, VERACODE-API-KEY and set them with the values from your Veracode account
+# Create the pipeline variable: VERACODE-POLICY-NAME and set it with the name of a default Veracode policy ex 'Veracode Recommended High' or custom policy name
+# Create CUSTOM-VERACODE-POLICY and set it to true if using a custom policy, otherwise false
 
 trigger: none
 
@@ -12,10 +17,6 @@ variables:
     value: MyProject.*.dll, MyProject.*.exe, MyProject.*.pdb
 
 steps:
-  - template: /templates/azure-key-vault-secrets.yml
-    parameters:
-      AzureSubscription: $(azure_connection_name)
-      KeyVaultName: my-keyvault
 
 # Download and extract the pipeline scan from Veracode and fetch the policy
   - script: curl -O -L https://downloads.veracode.com/securityscan/pipeline-scan-LATEST.zip
@@ -26,35 +27,25 @@ steps:
       archiveFilePatterns: 'pipeline-scan-LATEST.zip'
       cleanDestinationFolder: false
     displayName: Extract Veracode pipeline scan
-
-  - script: java -jar pipeline-scan.jar --veracode_api_id "$(VERACODE-API-ID)" --veracode_api_key "$(VERACODE-API-KEY)" --request_policy "Name Of Policy"
+    
+# If using a custom security policy, download it from Veracode. Downloading built-in policies will error out.
+  - script: java -jar pipeline-scan.jar --veracode_api_id "$(VERACODE-API-ID)" --veracode_api_key "$(VERACODE-API-KEY)" --request_policy "$(VERACODE-POLICY-NAME)"
     env:
       VERACODE_API_ID: $(VERACODE-API-ID)
       VERACODE_API_KEY: $(VERACODE-API-KEY)
+    condition: eq(variables['VERACODE-CUSTOM-POLICY'], 'true')
     displayName: Fetch security policy
 
-# Zip and scan Javascript files in the entire project
+# Zip and scan Javascript and Typescript files in the entire project
   - powershell: |
-      Get-ChildItem -Path "$(System.DefaultWorkingDirectory)\*.js", "$(System.DefaultWorkingDirectory)\package-lock.json", "$(System.DefaultWorkingDirectory)\package.json" -Recurse -Force | Compress-Archive -DestinationPath "$(Build.ArtifactStagingDirectory)\$(Build.BuildId)-javascript.zip"
-    displayName: Zip Javascript files
+      Get-ChildItem -Path "$(System.DefaultWorkingDirectory)\*.js", "$(System.DefaultWorkingDirectory)\*.ts", "$(System.DefaultWorkingDirectory)\package-lock.json", "$(System.DefaultWorkingDirectory)\package.json" -Recurse -Force | Compress-Archive -DestinationPath "$(Build.ArtifactStagingDirectory)\$(Build.BuildId)-javascript.zip"
+    displayName: Zip Javascript and Typescript files
 
-  - script: java -jar pipeline-scan.jar --veracode_api_id "$(VERACODE-API-ID)" --veracode_api_key "$(VERACODE-API-KEY)" --file "$(Build.ArtifactStagingDirectory)\$(Build.BuildId)-javascript.zip" --policy_file="Name_Of_Policy.json" --issue_details true
+  - script: java -jar pipeline-scan.jar --veracode_api_id "$(VERACODE-API-ID)" --veracode_api_key "$(VERACODE-API-KEY)" --file "$(Build.ArtifactStagingDirectory)\$(Build.BuildId)-javascript.zip" --policy_name="$(VERACODE-POLICY-NAME)" --issue_details true
     env:
       VERACODE_API_ID: $(VERACODE-API-ID)
       VERACODE_API_KEY: $(VERACODE-API-KEY)
-    displayName: Run Veracode pipeline scan on Javascript files
-    continueOnError: true
-
-# Zip and scan Typescript files in the entire project
-  - powershell: |
-      Get-ChildItem -Path "$(System.DefaultWorkingDirectory)\*.ts", "$(System.DefaultWorkingDirectory)\package-lock.json", "$(System.DefaultWorkingDirectory)\package.json" -Recurse -Force | Compress-Archive -DestinationPath "$(Build.ArtifactStagingDirectory)\$(Build.BuildId)-typescript.zip"
-    displayName: Zip Typescript files
-
-  - script: java -jar pipeline-scan.jar --veracode_api_id "$(VERACODE-API-ID)" --veracode_api_key "$(VERACODE-API-KEY)" --file "$(Build.ArtifactStagingDirectory)\$(Build.BuildId)-typescript.zip" --policy_file="Name_Of_Policy.json" --issue_details true
-    env:
-      VERACODE_API_ID: $(VERACODE-API-ID)
-      VERACODE_API_KEY: $(VERACODE-API-KEY)
-    displayName: Run Veracode pipeline scan on Typescript files
+    displayName: Run Veracode pipeline scan on Javascript and Typescript files
     continueOnError: true
 
 # Build, zip and scan DotNet files in the entire project
@@ -86,9 +77,17 @@ steps:
       Compress-Archive -DestinationPath "$(Build.ArtifactStagingDirectory)\$(Build.BuildId)-dotnet-compressed.zip"
     displayName: Zip DotNet files
 
-  - script: java -jar pipeline-scan.jar --veracode_api_id "$(VERACODE-API-ID)" --veracode_api_key "$(VERACODE-API-KEY)" --file "$(Build.ArtifactStagingDirectory)\$(Build.BuildId)-dotnet-compressed.zip" --policy_file="Name_Of_Policy.json" --issue_details true
+  - script: java -jar pipeline-scan.jar --veracode_api_id "$(VERACODE-API-ID)" --veracode_api_key "$(VERACODE-API-KEY)" --file "$(Build.ArtifactStagingDirectory)\$(Build.BuildId)-dotnet-compressed.zip" --policy_name="$(VERACODE-POLICY-NAME)" --issue_details true
     env:
       VERACODE_API_ID: $(VERACODE-API-ID)
       VERACODE_API_KEY: $(VERACODE-API-KEY)
     displayName: Run Veracode pipeline scan on DotNet files
     continueOnError: true
+    
+# Publish Veracode output file to build artifacts
+  - task: PublishBuildArtifacts@1
+    displayName: Create Build Artifact for Veracode Pipeline Scan Results
+    inputs:
+      PathtoPublish: "results.json"
+      ArtifactName: "Build"
+      publishLocation: "Container"


### PR DESCRIPTION
Added documentation steps to header
Migrated from KeyVault to pipeline variables
Added condition to download Veracode policy file - would error out previously if using built-in policy
Combined JS & TS steps to be single step, to mirror the format of veracode-policy-scan.yml file
Added artifact publish step to publish veracode scan file results.json as a build artifact